### PR TITLE
Skip setting title when empty title and when running on MacOS

### DIFF
--- a/src/ProcessDetails.php
+++ b/src/ProcessDetails.php
@@ -53,8 +53,8 @@ class ProcessDetails {
 	 * @return void
 	 */
 	public static function setProcessTitle($title, array $replacements = array()) {
-		// skip empty title names
-		if (trim($title) == '') {
+		// skip when empty title names or running on MacOS
+		if (trim($title) == '' || PHP_OS == 'Darwin') {
 			return;
 		}
 		// 1. replace the values


### PR DESCRIPTION
Trying to set process title when running on MacOS produces following error when running on PHP 5.5 or 5.6:

```
cli_set_process_title(): cli_set_process_title had an error: Not initialized correctly
```

These are the errors when running tests without this fix:

```
.SEEEF

Time: 21.14 seconds, Memory: 4.25Mb

There were 3 errors:

1) QXS\Tests\WorkerPool\WorkerPoolTest::testGetters
cli_set_process_title(): cli_set_process_title had an error: Not initialized correctly

/Users/danielcosta/src/WorkerPool/src/ProcessDetails.php:79
/Users/danielcosta/src/WorkerPool/src/WorkerPool.php:245
/Users/danielcosta/src/WorkerPool/tests/WorkerPoolTest.php:59

2) QXS\Tests\WorkerPool\WorkerPoolTest::testSetters
cli_set_process_title(): cli_set_process_title had an error: Not initialized correctly

/Users/danielcosta/src/WorkerPool/src/ProcessDetails.php:79
/Users/danielcosta/src/WorkerPool/src/WorkerPool.php:245
/Users/danielcosta/src/WorkerPool/tests/WorkerPoolTest.php:117

3) QXS\Tests\WorkerPool\WorkerPoolTest::testDestroyException
cli_set_process_title(): cli_set_process_title had an error: Not initialized correctly

/Users/danielcosta/src/WorkerPool/src/ProcessDetails.php:79
/Users/danielcosta/src/WorkerPool/src/WorkerPool.php:245
/Users/danielcosta/src/WorkerPool/tests/WorkerPoolTest.php:150

--

There was 1 failure:

1) QXS\Tests\WorkerPool\WorkerPoolTest::testPingWorkers
An unexpected exception was thrown.
Failed asserting that false is true.
```

And this is the result with the fix:

```
.S....

Time: 3.71 seconds, Memory: 4.50Mb

OK, but incomplete, skipped, or risky tests!
Tests: 6, Assertions: 22, Skipped: 1.
```

We should skip setting process title on MacOS.
