### PR TITLE
Fix namespace of jeremeamia/superclosure

### DIFF
--- a/src/SerializableWorkerClosure.php
+++ b/src/SerializableWorkerClosure.php
@@ -5,7 +5,7 @@
 
 namespace QXS\WorkerPool;
 
-use Jeremeamia\SuperClosure\SerializableClosure;
+use SuperClosure\SerializableClosure;
 
 /**
  * The Serializeable Worker Closure


### PR DESCRIPTION
php parallelClosure2.php
`
PHP Fatal error:  Uncaught Error: Class 'Jeremeamia\SuperClosure\SerializableClosure' not found in /path/to/myproject/app/vendor/qxsch/worker-pool/src/SerializableWorkerClosure.php:25`

It seems that the namespace is changed now. You can check that [here].(https://github.com/jeremeamia/super_closure/blob/master/src/SerializableClosure.php)