### PR TITLE
fix: recive ctrl+c signal kill  child process

### DIFF
--- a/src/WorkerPool.php
+++ b/src/WorkerPool.php
@@ -26,7 +26,7 @@ class WorkerPool implements \Iterator, \Countable {
 
 	/** @var array signals, that should be watched */
 	protected $signals = array(
-		SIGCHLD, SIGTERM, SIGHUP, SIGUSR1
+		SIGCHLD, SIGTERM, SIGHUP, SIGUSR1, SIGINT
 	);
 
 	/** @var bool is the pool created? (children forked) */
@@ -339,6 +339,7 @@ class WorkerPool implements \Iterator, \Countable {
 		while (TRUE) {
 			$output = array('pid' => getmypid());
 			try {
+				pcntl_signal_dispatch();
 				$replacements['state'] = 'free';
 				ProcessDetails::setProcessTitle($this->childProcessTitleFormat, $replacements);
 				$cmd = $simpleSocket->receive();


### PR DESCRIPTION
If the abnormal main process exits abnormally before the repair, the child process will remain.

```test.php
$wp=new \QXS\WorkerPool\WorkerPool();
            $wp->setWorkerPoolSize(8)
               ->create(new \QXS\WorkerPool\ClosureWorker(
                function($input, $semaphore, $storage) {
                    usleep(5000);
                    echo $input;
                }
                }
));

for ($i = 0; $i < 20; $i ++) {
$wp->run($i);
}

$wp->waitForAllWorkers();
$wp->destroy();
```
run `php ./test.php` and `ctrl+c` keydown;

