### PR TITLE
array_shift should not be used on associative array because it reindexes it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1.0",
+		"php": ">=7.3.0",
 		"ext-pcntl": "*",
 		"ext-posix": "*",
 		"ext-sysvsem": "*",

--- a/src/ProcessDetailsCollection.php
+++ b/src/ProcessDetailsCollection.php
@@ -122,7 +122,8 @@ class ProcessDetailsCollection implements \IteratorAggregate {
 		if ($this->getFreeProcessesCount() === 0) {
 			return NULL;
 		}
-		$freePid = array_shift($this->freeProcessIds);
+		$freePid = array_key_first($this->freeProcessIds);
+		unset($this->freeProcessIds[$freePid]);
 		if ($freePid === NULL) {
 			return NULL;
 		}


### PR DESCRIPTION
```
% php -a
Interactive shell

php > $x = [100 => 100, 200 => 200, 300 => 300];
php > echo json_encode($x);
{"100":100,"200":200,"300":300}
php > array_shift($x);
php > echo json_encode($x);
[200,300]
```